### PR TITLE
Fix white screen after update

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -40,6 +40,31 @@ export default function Document() {
             <body>
                 <Main />
                 <NextScript />
+                {/* Fallback: ensure body becomes visible even if hydration fails */}
+                <script
+                    dangerouslySetInnerHTML={{
+                        __html: `
+                            (function() {
+                                try {
+                                    var foucStyle = document.querySelector('style[data-next-hide-fouc]');
+                                    if (foucStyle) {
+                                        // If hydration hasn't removed it quickly, remove as a safety net
+                                        setTimeout(function() {
+                                            if (foucStyle && foucStyle.parentNode) {
+                                                foucStyle.parentNode.removeChild(foucStyle);
+                                            }
+                                            if (document && document.body) {
+                                                document.body.style.display = 'block';
+                                            }
+                                        }, 1200);
+                                    }
+                                } catch (e) {
+                                    // no-op
+                                }
+                            })();
+                        `,
+                    }}
+                />
             </body>
         </Html>
     )


### PR DESCRIPTION
Add a fallback script to `pages/_document.js` to ensure the body becomes visible if hydration fails to remove the FOUC-hiding style.

The framework's FOUC (Flash Of Unstyled Content) protection style was persisting, leaving the `body` element with `display: none` and causing a white screen. This script acts as a safety net to force the body visible if hydration doesn't clear the style quickly.

---
<a href="https://cursor.com/background-agent?bcId=bc-df3f8247-3331-4db0-8e96-685ca93544dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-df3f8247-3331-4db0-8e96-685ca93544dd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

